### PR TITLE
Remove trailing spaces after line continuation characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ unzip -q ~/.m2/repository/org/forgerock/opendj/opendj-server/7.5.0-SNAPSHOT/open
 
 export DEPLOYMENT_ID=ADaMkVIXfryp4tZN3_0V4WoB3BZc9SQ5CBVN1bkVDE6OSY5Kl7pIibg
 
-./opendj/setup \                                                                                    
+./opendj/setup \
  --serverId evaluation-only \
  --deploymentId $DEPLOYMENT_ID \
  --deploymentIdPassword password \
@@ -21,8 +21,8 @@ export DEPLOYMENT_ID=ADaMkVIXfryp4tZN3_0V4WoB3BZc9SQ5CBVN1bkVDE6OSY5Kl7pIibg
  --adminConnectorPort 4444 \
  --ldapPort 1389 \
  --enableStartTls \
- --ldapsPort 1636 \     
- --httpsPort 8443 \                          
+ --ldapsPort 1636 \
+ --httpsPort 8443 \
  --replicationPort 8989 \
  --bootstrapReplicationServer localhost:8989 \
  --profile ds-evaluation \


### PR DESCRIPTION
The trailing spaces cause a failure like this:

```
% ./opendj/setup \                                          
 --serverId evaluation-only \
 --deploymentId $DEPLOYMENT_ID \
 --deploymentIdPassword password \
 --rootUserDN uid=admin \
 --rootUserPassword password \
 --monitorUserPassword password \
 --hostname localhost \
 --adminConnectorPort 4444 \
 --ldapPort 1389 \
 --enableStartTls \
 --ldapsPort 1636 \
 --httpsPort 8443 \
 --replicationPort 8989 \
 --bootstrapReplicationServer localhost:8989 \
 --profile ds-evaluation \
 --start \
 --acceptLicense
An error occurred while parsing the command-line arguments: Argument ” ” does
not start with one or two dashes and unnamed trailing arguments are not
allowedSee “setup --help” to get more usage helpzsh: command not found: --serverId
zsh: command not found: --httpsPort
zsh: command not found: --replicationPort
```