### PR TITLE
Fix issue/1: Alert user to authenticate if necessary

### DIFF
--- a/src/layouts/default/View.vue
+++ b/src/layouts/default/View.vue
@@ -1,9 +1,11 @@
 <template>
   <v-main>
+    <v-alert v-if="store.message" title="Info" type="info" closable>{{ store.message }}</v-alert>
     <router-view />
   </v-main>
 </template>
 
 <script setup>
-  //
+import { useAppStore } from '@/store/app'
+const store = useAppStore()
 </script>

--- a/src/pages/search.vue
+++ b/src/pages/search.vue
@@ -48,7 +48,7 @@ const store = useAppStore()
 const terms = ref('')
 const results = ref('')
 const entries = computed(() => {
-    if (!results) return []
+    if (!results.value) return []
     let formatted = []
     results.value.forEach(result => {
         formatted.push({
@@ -76,6 +76,6 @@ function search() {
     })
     axios.get('/hdap', config)
         .then((res) => { results.value = (res.data.result) ? res.data.result : [] })
-        .catch((error) => { console.log(error) }) // FixMe: handle token expiry
+        .catch((error) => { store.handleAuthError(error) })
 }
 </script>

--- a/src/pages/view/[[id]]+.vue
+++ b/src/pages/view/[[id]]+.vue
@@ -32,7 +32,7 @@ function read() {
                 attributes.value.push({ 'attribute': key, 'value': formatValueAsString(value) })
             }
         })
-        .catch((error) => { console.log(error) }) // FixMe: handle token expiry
+        .catch((error) => { store.handleAuthError(error) })
 }
 
 function formatValueAsString(value) {

--- a/src/store/app.js
+++ b/src/store/app.js
@@ -30,34 +30,70 @@ async function findEntry(email, password) {
 async function authenticate(entry) {
   if (!entry || !entry.dn) return
   const res = await axios.post(`/hdap/${entry.dn}?_action=authenticate`, {
-    password: `${entry.password}`
-  }, {
-    headers: { 'Content-Type': 'application/json' }
-  })
-  return res.data.access_token
+      password: `${entry.password}`
+    }, {
+      headers: { 'Content-Type': 'application/json' }
+    })
+  return res.data
+}
+
+function getExpInSecsSinceEpoch(secondsFromNow) {
+  // Make sure numbers are numbers here. Good grief!
+  return Number(getNowInSecsSinceEpoch()) + Number(secondsFromNow)
+}
+
+function getNowInSecsSinceEpoch() {
+  return Math.floor(new Date().getTime() / 1000)
+}
+
+function isJwtValid(expInSecondsSinceEpoch) {
+  return expInSecondsSinceEpoch > getNowInSecsSinceEpoch()
 }
 
 export const useAppStore = defineStore('app', () => {
   const authenticated = ref(false)
   const dn = ref('')
+  const expires = ref(0)
   const fullName = ref('')
+  const isSessionValid = ref(false)
   const jwt = ref('')
+  const message = ref('')
 
   function addAuthzHeader(request) {
-    if (!authenticated.value) return request
-    request.headers['Authorization'] = `Bearer ${jwt.value}`
+    if (authenticated.value && isJwtValid(expires.value)) {
+      request.headers['Authorization'] = `Bearer ${jwt.value}`
+    } else if (!isJwtValid(expires.value)) {
+      // The JWT expired, so log the user out.
+      message.value = 'Session expired. Logging out...'
+      logout()
+    }
     return request
+  }
+
+  function handleAuthError(error) {
+    if (error.response) {
+      if (error.response.status == 403) {
+        message.value = `${fullName.value} does not have access to this resource.`
+      }
+      if (error.response.status >= 500) {
+        message.value = `Server error ${error.response.status}`
+      }
+    }
+    console.error(error.config)
   }
 
   async function login(email, password) {
     try {
       const entry = await findEntry(email, password)
-      const token = await authenticate(entry)
-      if (token) {
+      const response = await authenticate(entry)
+      if (response) {
         authenticated.value = true
         dn.value = entry.dn
+        expires.value = getExpInSecsSinceEpoch(response.expires_in)
         fullName.value = entry.cn
-        jwt.value = token
+        isSessionValid.value = true
+        jwt.value = response.access_token
+        message.value = ''
       }
     } catch (error) {
       console.error(error)
@@ -67,16 +103,22 @@ export const useAppStore = defineStore('app', () => {
   function logout() {
     authenticated.value = false
     dn.value = ''
+    expires.value = 0
     fullName.value = ''
+    isSessionValid.value = false
     jwt.value = ''
   }
 
   return {
     authenticated,
     dn,
+    expires,
     fullName,
+    isSessionValid,
     jwt,
+    message,
     addAuthzHeader,
+    handleAuthError,
     login,
     logout
   }


### PR DESCRIPTION
When HDAP gets an invalid JWT, it responds with HTTP 401 and suggests HTTP Basic. The browser then pops up a modal to get the user to enter a username and password. On the web generally, that's a helpful workaround. But it you as an end user logged in as `bjensen@example.com:hifalutin`, you don't necessarily know you need to enter `dc=com/dc=example/ou=People/uid=bjensen:hifalutin` into the modal.

This patch works around the problem by logging the user out if the JWT has expired before issuing the request. It also adds a closable alert message to let the user know they're being logged out.

It further adds a couple more messages for HTTP 403 Unauthorized and HTTP 500+ errors.