### PR TITLE
Fix #11 allow selection and bulk delete of search results

### DIFF
--- a/src/store/hdap.js
+++ b/src/store/hdap.js
@@ -18,6 +18,7 @@ export const useHdapStore = defineStore('hdapStore', () => {
             if (currentJwt.value && isJwtExpired()) {
                 expireSession()
             }
+            message.value = ''
         })
     }
 


### PR DESCRIPTION
This patch lets you select search results one row at a time or everything at once.

The delete and bulk delete options are enabled. The edit options are not implemented yet.

<img width="1231" alt="image" src="https://github.com/markcraig/hdap-demo/assets/716031/6a449fea-ea00-45d6-adc0-86c66f415278">