### PR TITLE
Fix #14 Add breadcrumbs

### DIFF
--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -7,10 +7,18 @@
 </template>
 
 <script setup>
+import { onMounted } from 'vue';
 import DefaultBar from './default/AppBar.vue'
 import DefaultView from './default/View.vue'
+import { useHdapStore } from '@/store/hdap'
 import { useTheme } from 'vuetify'
+
+const hdapStore = useHdapStore()
 const theme = useTheme()
+
+onMounted(async () => {
+  await hdapStore.setServerCapabilities()
+})
 
 // Let the theme depend on the system setting:
 window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {

--- a/src/store/hdap.js
+++ b/src/store/hdap.js
@@ -53,6 +53,9 @@ export const useHdapStore = defineStore('hdapStore', () => {
     /** A human-readable message for the application user. */
     const message = ref('')
 
+    /** The capablities of the HDAP server as indicated in the root DSE. */
+    const serverCapabilities = ref('')
+
     /**
      * Returns the bearer token for the authenticated user, 
      * expiring the session if the token has expired.
@@ -113,6 +116,13 @@ export const useHdapStore = defineStore('hdapStore', () => {
     }
 
     /**
+     * Sets the server capabilities from the HDAP server.
+     */
+    async function setServerCapabilities() {
+        serverCapabilities.value = await hdap.read('', { _fields: '*,%2B' }, null)
+    }
+
+    /**
      * Enables settings to run this store in test mode.
      */
     function setTestMode() {
@@ -133,10 +143,12 @@ export const useHdapStore = defineStore('hdapStore', () => {
         currentJwt,
         friendlyUserName,
         message,
+        serverCapabilities,
         getCredentials,
         login,
         logout,
         setMessage,
+        setServerCapabilities,
         setTestMode,
         whoAmI
     }

--- a/src/tests/hdapStore.test.js
+++ b/src/tests/hdapStore.test.js
@@ -26,8 +26,13 @@ describe('HDAP store', () => {
     })
 
     it('logout should succeed', async () => {
-        expect(await await hdapStore.login(validCreds.id, validCreds.password)).toBeTruthy()
+        expect(await hdapStore.login(validCreds.id, validCreds.password)).toBeTruthy()
         expect(hdapStore.logout()).toBeFalsy()
         expect(hdapStore.whoAmI()).toBeFalsy()
+    })
+
+    it('namingContexts should include dc=com/dc=example', async () => {
+        await hdapStore.setServerCapabilities()
+        expect(hdapStore.serverCapabilities.namingContexts).toContain('dc=com/dc=example')
     })
 })


### PR DESCRIPTION
This patch adds breadcrumbs in the app bar. For example:

<img width="1162" alt="image" src="https://github.com/markcraig/hdap-demo/assets/716031/3db68e8c-8e74-4810-a8d6-a9cf707015ee">

Notice that the naming context base DN is one breadcrumb, not two.