### PR TITLE
Fix #10 Preserve search

### DIFF
--- a/src/layouts/default/Login.vue
+++ b/src/layouts/default/Login.vue
@@ -68,9 +68,11 @@
 import { ref } from 'vue'
 import { useHdap } from '@/helpers/hdap'
 import { useHdapStore } from '@/store/hdap'
+import { useSearchStore } from '@/store/search'
 
 const hdap = useHdap()
 const hdapStore = useHdapStore()
+const searchStore = useSearchStore()
 
 // UI settings
 let display = ref(false)
@@ -121,6 +123,7 @@ async function loginWithId() {
 }
 
 function logout() {
+    searchStore.$reset()
     hdapStore.logout()
 }
 </script>

--- a/src/store/hdap.js
+++ b/src/store/hdap.js
@@ -3,7 +3,6 @@ import { getCurrentInstance, onMounted, ref } from 'vue'
 import { jwtDecode } from 'jwt-decode'
 import { useHdap } from '@/helpers/hdap'
 
-// FixMe: this store needs automated testing
 export const useHdapStore = defineStore('hdapStore', () => {
     /*******************************
      * Internal fields and functions

--- a/src/store/search.js
+++ b/src/store/search.js
@@ -1,0 +1,39 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useSearchStore = defineStore('searchStore', () => {
+    const advancedSearchBase = ref('')
+    const advancedSearchQueryFilter = ref('true')
+    const advancedSearchScope = ref('one')
+    const advancedSearchCountOnly = ref(false)
+    const advancedSearchOperationalFields = ref(false)
+    const advancedSearchResults = ref('')
+    const basicSearchTerms = ref('')
+    const basicSearchResults = ref('')
+    const tab = ref('basic')
+
+    function $reset() {
+        advancedSearchBase.value = ''
+        advancedSearchQueryFilter.value = 'true'
+        advancedSearchScope.value = 'one'
+        advancedSearchCountOnly.value = false
+        advancedSearchOperationalFields.value = false
+        advancedSearchResults.value = ''
+        basicSearchTerms.value = ''
+        basicSearchResults.value = ''
+        tab.value = 'basic'
+    }
+
+    return {
+        advancedSearchBase,
+        advancedSearchCountOnly,
+        advancedSearchOperationalFields,
+        advancedSearchQueryFilter,
+        advancedSearchResults,
+        advancedSearchScope,
+        basicSearchResults,
+        basicSearchTerms,
+        $reset,
+        tab
+    }
+})


### PR DESCRIPTION
This patch moves search terms, query filters, results, etc. to a store.

For example, you can navigate away by clicking a link to search result, click the back button in the browser, and find your query and your results as you left them.