### PR TITLE
Fix #24 provide feedback when a request fails

### DIFF
--- a/src/layouts/default/Login.vue
+++ b/src/layouts/default/Login.vue
@@ -68,10 +68,12 @@
 import { ref } from 'vue'
 import { useHdap } from '@/helpers/hdap'
 import { useHdapStore } from '@/store/hdap'
+import { useMessageStore } from '@/store/message'
 import { useSearchStore } from '@/store/search'
 
 const hdap = useHdap()
 const hdapStore = useHdapStore()
+const messageStore = useMessageStore()
 const searchStore = useSearchStore()
 
 // UI settings
@@ -104,7 +106,7 @@ async function loginWithEmail() {
                 loginWithId()
             })
     } catch (error) {
-        hdapStore.setMessage(error.message)
+        messageStore.message = error.message
     }
 }
 
@@ -113,12 +115,12 @@ async function loginWithId() {
         hdapStore.login(id.value, password.value)
             .then(user => {
                 if (!user) {
-                    hdapStore.setMessage('Failed to log in')
+                    messageStore.message = 'Failed to log in'
                     return
                 }
             })
     } catch (error) {
-        hdapStore.setMessage(error.message)
+        messageStore.message = error.message
     }
 }
 

--- a/src/layouts/default/View.vue
+++ b/src/layouts/default/View.vue
@@ -1,11 +1,12 @@
 <template>
   <v-main>
-    <v-alert v-if="hdapStore.message" title="Info" type="info" closable>{{ hdapStore.message }}</v-alert>
+    <v-alert v-if="messageStore.message" :text="messageStore.message" icon="mdi-information-outline" title="Info"
+      type="info" closable @click:close="messageStore.message = ''"></v-alert>
     <router-view />
   </v-main>
 </template>
 
 <script setup>
-import { useHdapStore } from '@/store/hdap'
-const hdapStore = useHdapStore()
+import { useMessageStore } from '@/store/message'
+const messageStore = useMessageStore()
 </script>

--- a/src/pages/search.vue
+++ b/src/pages/search.vue
@@ -114,10 +114,12 @@
 import { computed, defineModel, ref, watch } from 'vue'
 import { useHdap } from '@/helpers/hdap'
 import { useHdapStore } from '@/store/hdap'
+import { useMessageStore } from '@/store/message'
 import { useSearchStore } from '@/store/search'
 
 const hdap = useHdap()
 const hdapStore = useHdapStore()
+const messageStore = useMessageStore()
 const searchStore = useSearchStore()
 
 const tab = ref('basic')
@@ -185,7 +187,7 @@ async function advancedSearch() {
 async function deleteItem(item) {
     await hdap
         .remove(item.link, null, null, hdapStore.getCredentials())
-        .catch(error => { hdapStore.setMessage(error.message) })
+        .catch(error => { messageStore.message = error.message })
     if (tab.value == 'basic') basicSearch()
     else advancedSearch()
 }
@@ -194,7 +196,7 @@ async function bulkDelete() {
     await selected.value.forEach(async (id) => {
         await hdap
             .remove(id, null, null, hdapStore.getCredentials())
-            .catch(error => { hdapStore.setMessage(error.message) })
+            .catch(error => { messageStore.message = error.message })
         selected.value.remove(id)
     })
     if (tab.value == 'basic') basicSearch()

--- a/src/store/hdap.js
+++ b/src/store/hdap.js
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { getCurrentInstance, onMounted, ref } from 'vue'
 import { jwtDecode } from 'jwt-decode'
 import { useHdap } from '@/helpers/hdap'
+import { useMessageStore } from '@/store/message'
 
 export const useHdapStore = defineStore('hdapStore', () => {
     /*******************************
@@ -10,13 +11,14 @@ export const useHdapStore = defineStore('hdapStore', () => {
 
     let hdap = useHdap()
     let skipForTests = false
+    const messageStore = useMessageStore()
 
     if (getCurrentInstance()) {
         onMounted(() => {
             if (currentJwt.value && isJwtExpired()) {
                 expireSession()
             }
-            message.value = ''
+            messageStore.message = ''
         })
     }
 
@@ -24,7 +26,7 @@ export const useHdapStore = defineStore('hdapStore', () => {
         authenticatedUser.value = ''
         currentJwt.value = ''
         friendlyUserName.value = ''
-        message.value = (showMessage) ? 'Session expired' : ''
+        messageStore.message = (showMessage) ? 'Session expired' : ''
     }
 
     function isJwtExpired() {
@@ -32,7 +34,7 @@ export const useHdapStore = defineStore('hdapStore', () => {
     }
 
     async function notifyError(message) {
-        message.value = message
+        messageStore.message = message
         throw new Error(message)
     }
 
@@ -48,9 +50,6 @@ export const useHdapStore = defineStore('hdapStore', () => {
 
     /** The most human-readable name for the authenticated user. */
     const friendlyUserName = ref('')
-
-    /** A human-readable message for the application user. */
-    const message = ref('')
 
     /** The capablities of the HDAP server as indicated in the root DSE. */
     const serverCapabilities = ref('')
@@ -94,7 +93,7 @@ export const useHdapStore = defineStore('hdapStore', () => {
         if (!user) notifyError('Could not read authenticated user resource')
         authenticatedUser.value = user
         friendlyUserName.value = (user.cn) ? user.cn[0] : (user.mail) ? user.mail[0] : id
-        message.value = ''
+        messageStore.message = ''
         return user
     }
 
@@ -104,14 +103,6 @@ export const useHdapStore = defineStore('hdapStore', () => {
     function logout() {
         expireSession()
         if (!skipForTests) this.router.push('/')
-    }
-
-    /**
-     * Sets the message field.
-     * @param {*} messageStr The new message string
-     */
-    function setMessage(messageStr) {
-        message.value = messageStr
     }
 
     /**
@@ -141,12 +132,10 @@ export const useHdapStore = defineStore('hdapStore', () => {
         authenticatedUser,
         currentJwt,
         friendlyUserName,
-        message,
         serverCapabilities,
         getCredentials,
         login,
         logout,
-        setMessage,
         setServerCapabilities,
         setTestMode,
         whoAmI

--- a/src/store/message.js
+++ b/src/store/message.js
@@ -1,0 +1,9 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useMessageStore = defineStore('messageStore', () => {
+    /** A human-readable message for the application user. */
+    const message = ref('')
+
+    return { message }
+})

--- a/src/tests/hdap.test.js
+++ b/src/tests/hdap.test.js
@@ -1,8 +1,7 @@
 import { expect, test } from 'vitest'
 import { useHdap } from '@/helpers/hdap'
 
-const hdap = useHdap('http://localhost:3000/hdap') // Run HDAP and `npm run dev` locally
-
+const hdap = useHdap('http://localhost:3000/hdap', true) // Run HDAP and `npm run dev` locally
 const adminCreds = { id: 'uid=admin', password: 'password' }
 
 test('authentication should succeed with valid credentials', async () => {


### PR DESCRIPTION
This patch posts an alert when an HDAP HTTP request fails. For example:
<img width="1311" alt="image" src="https://github.com/markcraig/hdap-demo/assets/716031/1c0575b9-7380-4209-b194-aefca9f75efe">

It factors out the messages into their own store as several components need to provide this sort of feedback to the user.